### PR TITLE
Fix auth service regressions

### DIFF
--- a/internal/api_service/auth/routes/auth_router.py
+++ b/internal/api_service/auth/routes/auth_router.py
@@ -21,7 +21,7 @@ async def login_for_access_token(
   form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
   session: AsyncSession = Depends[get_session]
 ) -> Token:
-  user: Accounts = authenticate_user(form_data.email, form_data.password, session)
+  user: Accounts | None = await authenticate_user(form_data.username, form_data.password, session)
   if not user:
     raise HTTPException(
       status_code=status.HTTP_401_UNAUTHORIZED,
@@ -31,7 +31,8 @@ async def login_for_access_token(
   access_token_expires = timedelta(minutes=30)
   token = create_access_token(
     data={
-      "sub": user.email  
-    }, 
-    expires_delta=access_token_expires)
+      "sub": user.email
+    },
+    expires_delta=access_token_expires
+  )
   return Token(access_token=token, token_type="bearer")

--- a/internal/api_service/auth/services/auth_service.py
+++ b/internal/api_service/auth/services/auth_service.py
@@ -8,41 +8,44 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from internal.api_service.auth.models.token import TokenData
 from internal.api_service.auth.utils.auth_utils import verify_password
 from internal.api_service.users.services.user_service import get_user_by_email
-from main import app, get_session
+from internal.api_service.main import get_session
 import os
 from datetime import datetime, timedelta, timezone
 
-JWT_SECRET_KEY=os.getenv("JWT_SECRET_KEY")
-ALGORITHM="HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+ALGORITHM = "HS256"
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
 
 
-def create_access_token(data: dict, expires_delta: timedelta | None = None):
-  to_encode = data.copy()
-  if expires_delta:
-    expire = datetime.now(timezone.utc) + expires_delta
-  else:
-    expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+def _require_secret_key() -> str:
+  if not JWT_SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY environment variable is not set")
+  return JWT_SECRET_KEY
 
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+  secret_key = _require_secret_key()
+  to_encode = data.copy()
+  expire = datetime.now(timezone.utc) + (expires_delta or timedelta(minutes=15))
   to_encode.update({"exp": expire})
-  encoded_jwt = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=ALGORITHM)
+  encoded_jwt = jwt.encode(to_encode, secret_key, algorithm=ALGORITHM)
   return encoded_jwt
 
 
-async def authenticate_user(email: str, password: str, session: AsyncSession = Depends[get_session]) -> Accounts:
-  """
-  Returns account of type 'Account'
-  """
+async def authenticate_user(email: str, password: str, session: AsyncSession) -> Accounts | None:
+  """Validate user credentials and return the matching account."""
   user = await get_user_by_email(email, session)
   if not user:
-    return False
-  if not verify_password(password,user["PSWRD_HASH"]):
-    return False
-  return user 
+    return None
+  if not verify_password(password, user.pswrd_hash):
+    return None
+  return user
 
 
-async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], session: AsyncSession = Depends[get_session]):
+async def get_current_user(
+  token: Annotated[str, Depends(oauth2_scheme)],
+  session: AsyncSession = Depends(get_session)
+) -> Accounts:
   """Get the current user from the JWT token."""
   credentials_exception = HTTPException(
     status_code=status.HTTP_401_UNAUTHORIZED,
@@ -51,19 +54,19 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], sessio
   )
 
   try:
-    payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[ALGORITHM])
-    email: str = payload.get("sub")
+    payload = jwt.decode(token, _require_secret_key(), algorithms=[ALGORITHM])
+    email: str | None = payload.get("sub")
     if email is None:
       raise credentials_exception
     token_data = TokenData(email=email)
   except InvalidTokenError:
     raise credentials_exception
 
-  user = get_user_by_email(email=token_data.email, session=session)
+  user = await get_user_by_email(email=token_data.email, session=session)
   if user is None:
     raise credentials_exception
   return user
 
 
-async def get_current_active_user(current_user: Accounts = Depends(get_current_user)):
+async def get_current_active_user(current_user: Accounts = Depends(get_current_user)) -> Accounts:
   return current_user

--- a/internal/api_service/main.py
+++ b/internal/api_service/main.py
@@ -8,7 +8,12 @@ import os
 
 from internal.api_service.auth.routes import auth_router
 
-db_conn_string = f"postgresql+asyncpg://{os.getenv("POSTGRES_USER")}:{os.getenv("POSTGRES_PASSWORD")}@{os.getenv("POSTGRES_HOST")}:{os.getenv("POSTGRES_PORT")}/{os.getenv("DB_NAME")}"
+db_conn_string = (
+  "postgresql+asyncpg://"
+  f"{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}"
+  f"@{os.getenv('POSTGRES_HOST')}:{os.getenv('POSTGRES_PORT')}"
+  f"/{os.getenv('DB_NAME')}"
+)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -47,13 +52,23 @@ async def get_home():
   return {"Hello": "World"}
 
 # per-request session for READS
-async def get_session(request: Request) ->AsyncIterator[AsyncSession]:
-  session_maker = app.state.session_maker
+
+
+def _get_sessionmaker(request: Request) -> async_sessionmaker[AsyncSession]:
+  session_maker = getattr(request.app.state, "sessionmaker", None)
+  if session_maker is None:
+    raise RuntimeError("Database session factory is not configured")
+  return session_maker
+
+
+async def get_session(request: Request) -> AsyncIterator[AsyncSession]:
+  session_maker = _get_sessionmaker(request)
   async with session_maker() as session:
     yield session # lazy evaluation
 
+
 async def get_rw_session(request: Request) -> AsyncIterator[AsyncSession]:
-  session_maker = app.state.session_maker
+  session_maker = _get_sessionmaker(request)
   async with session_maker() as session:
     try:
       yield session


### PR DESCRIPTION
## Summary
- fix database connection string construction and session management helpers
- repair login route to await authentication and use OAuth2 form username field
- harden auth service credential validation and normalize database mapping helpers
- ensure session dependencies read the FastAPI app state for the configured session factory

## Testing
- python -m compileall internal/api_service

------
https://chatgpt.com/codex/tasks/task_e_68cdd95b20fc832c8e3a0e68c6c15d74