### PR TITLE
Integrate frontend login and API-backed imaging workflows

### DIFF
--- a/internal/frontend_service/run.py
+++ b/internal/frontend_service/run.py
@@ -1,11 +1,29 @@
-# code/run.py
-
 import sys
+
 from PyQt5.QtWidgets import QApplication
+
+from utils.api_client import ApiClient
+from viewers.login_viewer import LoginWindow
 from viewers.main_menu_viewer import MainMenu
 
-if __name__ == "__main__":
+
+def main() -> int:
     app = QApplication(sys.argv)
-    window = MainMenu()
-    window.show()
-    sys.exit(app.exec_())
+
+    api_client = ApiClient()
+    login_window = LoginWindow(api_client)
+    main_window_holder = {"window": None}
+
+    def handle_login_success() -> None:
+        main_menu = MainMenu(api_client)
+        main_window_holder["window"] = main_menu
+        main_menu.show()
+
+    login_window.login_successful.connect(handle_login_success)
+    login_window.show()
+
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/internal/frontend_service/utils/api_client.py
+++ b/internal/frontend_service/utils/api_client.py
@@ -1,0 +1,160 @@
+import json
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+
+class ApiClientError(RuntimeError):
+    """Raised when the API client encounters an unexpected response."""
+
+
+class ApiClient:
+    """Simple API client used by the PyQt frontend to talk to FastAPI."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or os.getenv("API_BASE_URL", "http://localhost:8000")).rstrip("/")
+        self._token: Optional[str] = None
+        self.user_aid: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Authentication helpers
+    # ------------------------------------------------------------------
+    def login(self, username: str, password: str) -> Dict[str, Any]:
+        """Authenticate the user and cache the returned JWT token."""
+
+        response = requests.post(
+            f"{self.base_url}/api/auth/token",
+            data={"username": username, "password": password},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload: Dict[str, Any] = response.json()
+        token = payload.get("access_token")
+        if not token:
+            raise ApiClientError("Missing access token in authentication response")
+        self._token = token
+        return payload
+
+    # ------------------------------------------------------------------
+    # Session helpers
+    # ------------------------------------------------------------------
+    def _auth_headers(self) -> Dict[str, str]:
+        if not self._token:
+            raise ApiClientError("Attempted to call an authenticated endpoint without logging in")
+        return {"Authorization": f"Bearer {self._token}"}
+
+    def get_sessions(self) -> List[Dict[str, Any]]:
+        response = requests.get(
+            f"{self.base_url}/user/sessions",
+            headers=self._auth_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        sessions: List[Dict[str, Any]] = response.json()
+        if sessions and not self.user_aid:
+            self.user_aid = sessions[0].get("aid")
+        return sessions
+
+    def get_session(self, session_id: int, aid: Optional[int] = None) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        resolved_aid = aid or self.user_aid
+        if resolved_aid is not None:
+            params["aid"] = resolved_aid
+        response = requests.get(
+            f"{self.base_url}/user/get-session/{session_id}",
+            headers=self._auth_headers(),
+            params=params or None,
+            timeout=60,
+        )
+        response.raise_for_status()
+        accession: Dict[str, Any] = response.json()
+        if accession and not self.user_aid:
+            self.user_aid = accession.get("aid")
+        return accession
+
+    def get_session_with_files(self, session_id: int, aid: Optional[int] = None) -> Dict[str, Any]:
+        accession = self.get_session(session_id, aid=aid)
+        files: List[Dict[str, Any]] = []
+        for file_info in accession.get("files", []):
+            url = file_info.get("s3_url")
+            if not url:
+                files.append(file_info)
+                continue
+            content = self.download_file(url)
+            files.append({**file_info, "content": content})
+        accession["files"] = files
+        return accession
+
+    def download_file(self, url: str) -> bytes:
+        response = requests.get(url, headers=self._auth_headers(), timeout=120)
+        response.raise_for_status()
+        return response.content
+
+    def download_session_to_directory(self, session_id: int, destination: str, aid: Optional[int] = None) -> List[str]:
+        accession = self.get_session_with_files(session_id, aid=aid)
+        saved_files: List[str] = []
+        for file_info in accession.get("files", []):
+            content: Optional[bytes] = file_info.get("content")
+            if not content:
+                continue
+            object_key = file_info.get("object_key") or f"file_{len(saved_files)}"
+            filename = os.path.basename(object_key.strip("/")) or f"file_{len(saved_files)}"
+            path = os.path.join(destination, filename)
+            with open(path, "wb") as handle:
+                handle.write(content)
+            saved_files.append(path)
+        return saved_files
+
+    # ------------------------------------------------------------------
+    # Upload helpers
+    # ------------------------------------------------------------------
+    def upload_accession(
+        self,
+        aid: int,
+        dicom_name: str,
+        file_paths: Iterable[str],
+        agaston_score: int | None = None,
+    ) -> Dict[str, Any]:
+        file_paths = list(file_paths)
+
+        accession_payload: Dict[str, Any] = {
+            "aid": aid,
+            "dicom_name": dicom_name,
+            "agaston_score": agaston_score or 0,
+            "files": [{"type": "slice"} for _ in file_paths],
+        }
+
+        files_data = []
+        for path in file_paths:
+            filename = os.path.basename(path)
+            files_data.append((
+                "files",
+                (filename, open(path, "rb"), "application/octet-stream"),
+            ))
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/user/new_accession",
+                headers=self._auth_headers(),
+                data={"accession": json.dumps(accession_payload)},
+                files=files_data,
+                timeout=120,
+            )
+            response.raise_for_status()
+            payload: Dict[str, Any] = response.json()
+            return payload
+        finally:
+            for _, file_tuple in files_data:
+                file_tuple[1].close()
+
+    # Convenience ----------------------------------------------------------------
+    def ensure_user_aid(self) -> int:
+        if self.user_aid is not None:
+            return self.user_aid
+        sessions = self.get_sessions()
+        if sessions:
+            self.user_aid = sessions[0].get("aid")
+            if self.user_aid is not None:
+                return self.user_aid
+        raise ApiClientError("Unable to determine the current user's AID")

--- a/internal/frontend_service/viewers/login_viewer.py
+++ b/internal/frontend_service/viewers/login_viewer.py
@@ -1,0 +1,78 @@
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QMessageBox,
+)
+import requests
+
+from utils.api_client import ApiClient, ApiClientError
+
+
+class LoginWindow(QWidget):
+    """Simple login window that authenticates the user via the API."""
+
+    login_successful = pyqtSignal()
+
+    def __init__(self, api_client: ApiClient):
+        super().__init__()
+        self.api_client = api_client
+
+        self.setWindowTitle("CT DICOM Viewer - Login")
+        self.setFixedSize(320, 220)
+
+        layout = QVBoxLayout()
+
+        self.status_label = QLabel("Enter your credentials")
+        layout.addWidget(self.status_label)
+
+        self.email_input = QLineEdit()
+        self.email_input.setPlaceholderText("Email")
+        layout.addWidget(self.email_input)
+
+        self.password_input = QLineEdit()
+        self.password_input.setPlaceholderText("Password")
+        self.password_input.setEchoMode(QLineEdit.Password)
+        layout.addWidget(self.password_input)
+
+        self.login_button = QPushButton("Login")
+        self.login_button.clicked.connect(self.attempt_login)
+        layout.addWidget(self.login_button)
+
+        self.setLayout(layout)
+
+    # ------------------------------------------------------------------
+    def attempt_login(self) -> None:
+        email = self.email_input.text().strip()
+        password = self.password_input.text()
+
+        if not email or not password:
+            QMessageBox.warning(self, "Missing information", "Email and password are required.")
+            return
+
+        self.login_button.setEnabled(False)
+        self.status_label.setText("Authenticating...")
+        try:
+            self.api_client.login(email, password)
+        except requests.HTTPError as exc:
+            self.status_label.setText("Enter your credentials")
+            QMessageBox.critical(self, "Login failed", f"Authentication failed: {exc.response.text}")
+            self.login_button.setEnabled(True)
+            return
+        except ApiClientError as exc:
+            self.status_label.setText("Enter your credentials")
+            QMessageBox.critical(self, "Login failed", str(exc))
+            self.login_button.setEnabled(True)
+            return
+        except requests.RequestException as exc:
+            self.status_label.setText("Enter your credentials")
+            QMessageBox.critical(self, "Login failed", f"Network error: {exc}")
+            self.login_button.setEnabled(True)
+            return
+
+        self.status_label.setText("Login successful")
+        self.login_successful.emit()
+        self.hide()

--- a/internal/frontend_service/viewers/main_menu_viewer.py
+++ b/internal/frontend_service/viewers/main_menu_viewer.py
@@ -1,56 +1,251 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton
-from viewers.single_slice_viewer import SingleSliceViewer
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+import pydicom
+import requests
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QInputDialog,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from utils.api_client import ApiClient, ApiClientError
 from viewers.full_stack_viewer import FullStackViewer
-from viewers.mask_side_by_side_viewer import MaskSideBySideViewer
 from viewers.mask_overlay_viewer import MaskOverlayViewer
+from viewers.mask_side_by_side_viewer import MaskSideBySideViewer
+from viewers.single_slice_viewer import SingleSliceViewer
+
 
 class MainMenu(QWidget):
-    def __init__(self):
+    def __init__(self, api_client: ApiClient):
         super().__init__()
+        self.api_client = api_client
+        self.sessions: Dict[int, Dict[str, Any]] = {}
+
         self.setWindowTitle("CT DICOM Viewer - Main Menu")
-        self.setFixedSize(400, 300)
+        self.setMinimumSize(520, 480)
 
         layout = QVBoxLayout()
 
-        # Basic Viewers
-        single_btn = QPushButton("Single Slice Viewer")
-        single_btn.clicked.connect(self.launch_single)
+        layout.addWidget(QLabel("Available sessions"))
 
-        full_btn = QPushButton("Full Stack Viewer")
-        full_btn.clicked.connect(self.launch_full)
+        self.session_list = QListWidget()
+        self.session_list.itemSelectionChanged.connect(self._update_button_states)
+        layout.addWidget(self.session_list)
 
-        layout.addWidget(single_btn)
-        layout.addWidget(full_btn)
+        viewer_buttons = QHBoxLayout()
+        self.single_btn = QPushButton("Single Slice Viewer")
+        self.single_btn.clicked.connect(self.launch_single)
+        viewer_buttons.addWidget(self.single_btn)
 
-        # Merged Side-by-Side Viewer
-        side_by_side_btn = QPushButton("Side-by-Side Viewer")
-        side_by_side_btn.clicked.connect(self.launch_side_by_side)
+        self.full_btn = QPushButton("Full Stack Viewer")
+        self.full_btn.clicked.connect(self.launch_full)
+        viewer_buttons.addWidget(self.full_btn)
+        layout.addLayout(viewer_buttons)
 
-        layout.addWidget(side_by_side_btn)
+        mask_buttons = QHBoxLayout()
+        self.side_btn = QPushButton("Side-by-Side Viewer")
+        self.side_btn.clicked.connect(self.launch_side_by_side)
+        mask_buttons.addWidget(self.side_btn)
 
-        # Overlay Viewer
-        overlay_btn = QPushButton("Overlay Viewer")
-        overlay_btn.clicked.connect(self.launch_overlay)
+        self.overlay_btn = QPushButton("Overlay Viewer")
+        self.overlay_btn.clicked.connect(self.launch_overlay)
+        mask_buttons.addWidget(self.overlay_btn)
+        layout.addLayout(mask_buttons)
 
-        layout.addWidget(overlay_btn)
+        action_buttons = QHBoxLayout()
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.load_sessions)
+        action_buttons.addWidget(refresh_btn)
+
+        download_btn = QPushButton("Download Session")
+        download_btn.clicked.connect(self.download_session)
+        action_buttons.addWidget(download_btn)
+
+        upload_btn = QPushButton("Upload New Accession")
+        upload_btn.clicked.connect(self.upload_accession)
+        action_buttons.addWidget(upload_btn)
+        layout.addLayout(action_buttons)
 
         self.setLayout(layout)
+        self._update_button_states()
+        self.load_sessions()
 
-    def launch_single(self):
-        # user uploads individual image of one slice
-        # user upload -> FastAPI -> {Postgres, S3} 
-        # sends confirmation/error back
-        self.single = SingleSliceViewer()
-        self.single.show()
+    # ------------------------------------------------------------------
+    def _update_button_states(self) -> None:
+        has_selection = bool(self.session_list.selectedItems())
+        for button in (self.single_btn, self.full_btn, self.side_btn, self.overlay_btn):
+            button.setEnabled(has_selection)
 
-    def launch_full(self):
-        self.full = FullStackViewer()
-        self.full.show()
+    def load_sessions(self) -> None:
+        try:
+            sessions = self.api_client.get_sessions()
+        except (requests.RequestException, ApiClientError) as exc:
+            QMessageBox.critical(self, "Error", f"Failed to load sessions: {exc}")
+            return
 
-    def launch_side_by_side(self):
-        self.side_by_side = MaskSideBySideViewer(mode="rgb")  # or "grayscale" if preferred
-        self.side_by_side.show()
+        self.session_list.clear()
+        self.sessions.clear()
+        for session in sessions:
+            dicom_id = session.get("dicom_id")
+            if dicom_id is None:
+                continue
+            created_at = session.get("created_at", "")
+            dicom_name = session.get("dicom_name", "Unnamed Study")
+            label = f"{dicom_name} (ID: {dicom_id})"
+            if created_at:
+                label = f"{label}\n{created_at}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, dicom_id)
+            self.session_list.addItem(item)
+            self.sessions[dicom_id] = session
 
-    def launch_overlay(self):
-        self.overlay = MaskOverlayViewer()
-        self.overlay.show()
+        self._update_button_states()
+
+    def _selected_session_id(self) -> Optional[int]:
+        items = self.session_list.selectedItems()
+        if not items:
+            return None
+        return items[0].data(Qt.UserRole)
+
+    def _fetch_accession(self) -> Optional[Dict[str, Any]]:
+        session_id = self._selected_session_id()
+        if session_id is None:
+            QMessageBox.information(self, "No selection", "Please select a session first.")
+            return None
+        try:
+            accession = self.api_client.get_session_with_files(session_id)
+        except requests.HTTPError as exc:
+            QMessageBox.critical(self, "Error", f"API error: {exc.response.text}")
+            return None
+        except (requests.RequestException, ApiClientError) as exc:
+            QMessageBox.critical(self, "Error", f"Failed to fetch session: {exc}")
+            return None
+        return accession
+
+    def _partition_files(self, accession: Dict[str, Any]) -> Tuple[List[pydicom.dataset.Dataset], List[np.ndarray]]:
+        dicom_slices: List[pydicom.dataset.Dataset] = []
+        mask_images: List[np.ndarray] = []
+
+        for file_info in accession.get("files", []):
+            content = file_info.get("content")
+            if not content:
+                continue
+            file_type = file_info.get("type", "slice")
+            buffer = BytesIO(content)
+            try:
+                dataset = pydicom.dcmread(buffer, force=True)
+                if file_type == "mask":
+                    mask_images.append(dataset.pixel_array.astype(np.uint8))
+                else:
+                    dicom_slices.append(dataset)
+                continue
+            except Exception:
+                buffer.seek(0)
+
+            if file_type == "mask":
+                array = cv2.imdecode(np.frombuffer(buffer.read(), dtype=np.uint8), cv2.IMREAD_UNCHANGED)
+                if array is not None:
+                    mask_images.append(array)
+
+        if dicom_slices:
+            dicom_slices.sort(key=lambda ds: int(getattr(ds, "InstanceNumber", 0)))
+        return dicom_slices, mask_images
+
+    # ------------------------------------------------------------------
+    def launch_single(self) -> None:
+        accession = self._fetch_accession()
+        if not accession:
+            return
+        dicom_slices, _ = self._partition_files(accession)
+        if not dicom_slices:
+            QMessageBox.information(self, "No slices", "The selected session has no slice images to display.")
+            return
+        viewer = SingleSliceViewer(accession=accession, dicom_slices=dicom_slices)
+        viewer.show()
+
+    def launch_full(self) -> None:
+        accession = self._fetch_accession()
+        if not accession:
+            return
+        dicom_slices, _ = self._partition_files(accession)
+        if not dicom_slices:
+            QMessageBox.information(self, "No slices", "The selected session has no slice images to display.")
+            return
+        viewer = FullStackViewer(dicom_slices=dicom_slices)
+        viewer.show()
+
+    def launch_side_by_side(self) -> None:
+        accession = self._fetch_accession()
+        if not accession:
+            return
+        dicom_slices, masks = self._partition_files(accession)
+        if not dicom_slices or not masks:
+            QMessageBox.information(self, "Incomplete data", "Side-by-side view requires both slices and masks.")
+            return
+        viewer = MaskSideBySideViewer(dicom_slices=dicom_slices, mask_images=masks, mode="rgb")
+        viewer.show()
+
+    def launch_overlay(self) -> None:
+        accession = self._fetch_accession()
+        if not accession:
+            return
+        dicom_slices, masks = self._partition_files(accession)
+        if not dicom_slices or not masks:
+            QMessageBox.information(self, "Incomplete data", "Overlay view requires both slices and masks.")
+            return
+        viewer = MaskOverlayViewer(dicom_slices=dicom_slices, mask_images=masks)
+        viewer.show()
+
+    # ------------------------------------------------------------------
+    def download_session(self) -> None:
+        session_id = self._selected_session_id()
+        if session_id is None:
+            QMessageBox.information(self, "No selection", "Please select a session to download.")
+            return
+        destination = QFileDialog.getExistingDirectory(self, "Select download directory")
+        if not destination:
+            return
+        try:
+            saved_files = self.api_client.download_session_to_directory(session_id, destination)
+        except (requests.RequestException, ApiClientError) as exc:
+            QMessageBox.critical(self, "Download failed", f"Unable to download session: {exc}")
+            return
+        QMessageBox.information(
+            self,
+            "Download complete",
+            f"Saved {len(saved_files)} files to {destination}",
+        )
+
+    def upload_accession(self) -> None:
+        aid = self.api_client.user_aid
+        if aid is None:
+            aid, ok = QInputDialog.getInt(self, "Patient ID", "Enter the patient AID:")
+            if not ok:
+                return
+        dicom_name, ok = QInputDialog.getText(self, "Accession Name", "Enter a name for the study:")
+        if not ok or not dicom_name:
+            return
+        files, _ = QFileDialog.getOpenFileNames(self, "Select DICOM files", filter="DICOM Files (*.dcm);;All Files (*)")
+        if not files:
+            return
+        try:
+            self.api_client.upload_accession(aid, dicom_name, files)
+        except requests.HTTPError as exc:
+            QMessageBox.critical(self, "Upload failed", f"API error: {exc.response.text}")
+            return
+        except (requests.RequestException, ApiClientError) as exc:
+            QMessageBox.critical(self, "Upload failed", f"Unable to upload accession: {exc}")
+            return
+        QMessageBox.information(self, "Upload complete", "Accession uploaded successfully.")
+        self.load_sessions()

--- a/internal/frontend_service/viewers/mask_overlay_viewer.py
+++ b/internal/frontend_service/viewers/mask_overlay_viewer.py
@@ -1,25 +1,35 @@
-# viewers/mask_overlay_viewer.py
-
 import os
+from typing import List, Optional
+
 import cv2
 import numpy as np
 import pydicom
-from PyQt5.QtWidgets import (
-    QWidget, QLabel, QVBoxLayout, QHBoxLayout, QSlider,
-    QPushButton, QFileDialog, QMessageBox
-)
 from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QPixmap, QImage
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
 
 from utils.dicom_loader import load_dicom_slices
-from utils.image_utils import get_qimage
+
 
 class MaskOverlayViewer(QWidget):
-    def __init__(self):
+    def __init__(
+        self,
+        dicom_slices: Optional[List[pydicom.dataset.Dataset]] = None,
+        mask_images: Optional[List[np.ndarray]] = None,
+    ):
         super().__init__()
         self.setWindowTitle("Overlay Mask Viewer")
-        self.dicom_slices = []
-        self.mask_images = []
+        self.dicom_slices = dicom_slices or []
+        self.mask_images = mask_images or []
         self.current_index = 0
 
         self.timer = QTimer()
@@ -50,9 +60,21 @@ class MaskOverlayViewer(QWidget):
         layout.addLayout(control_layout)
         self.setLayout(layout)
 
-        self.load_folders()
+        if self.dicom_slices and self.mask_images:
+            self._configure_slider()
+            self.update_image(0)
+        else:
+            self.load_folders()
+
         self.resize(800, 800)
         self.show()
+
+    def _configure_slider(self) -> None:
+        if not self.dicom_slices or not self.mask_images:
+            return
+        length = min(len(self.dicom_slices), len(self.mask_images))
+        self.slider.setMaximum(length - 1)
+        self.slider.setValue(0)
 
     def load_folders(self):
         ct_folder = QFileDialog.getExistingDirectory(self, "Select DICOM Slice Folder")
@@ -69,17 +91,16 @@ class MaskOverlayViewer(QWidget):
             QMessageBox.critical(self, "Mismatch", "DICOM and mask counts do not match.")
             return
 
-        self.slider.setMaximum(len(self.dicom_slices) - 1)
-        self.slider.setValue(0)
+        self._configure_slider()
         self.update_image(0)
 
-    def load_mask_images(self, folder_path):
+    def load_mask_images(self, folder_path: str) -> List[np.ndarray]:
         dicom_map = {
             int(getattr(ds, "InstanceNumber", i)): i
             for i, ds in enumerate(self.dicom_slices)
         }
 
-        mask_images = [None] * len(self.dicom_slices)
+        mask_images: List[np.ndarray] = [None] * len(self.dicom_slices)  # type: ignore
 
         for fname in os.listdir(folder_path):
             if fname.startswith('.'):
@@ -103,8 +124,13 @@ class MaskOverlayViewer(QWidget):
                 dcm = pydicom.dcmread(file_path)
                 img = dcm.pixel_array.astype(np.uint8)
                 mask_images[idx] = img
-            except:
-                continue
+            except Exception:
+                try:
+                    raw = cv2.imread(file_path, cv2.IMREAD_UNCHANGED)
+                    if raw is not None:
+                        mask_images[idx] = raw
+                except Exception:
+                    continue
 
         return [img for img in mask_images if img is not None]
 
@@ -120,7 +146,6 @@ class MaskOverlayViewer(QWidget):
         base_img_norm = cv2.normalize(base_img, None, 0, 255, cv2.NORM_MINMAX)
         base_rgb = cv2.cvtColor(base_img_norm.astype(np.uint8), cv2.COLOR_GRAY2RGB)
 
-        # Overlay red where mask is 1
         overlay = base_rgb.copy()
         overlay[mask > 0] = [255, 0, 0]  # Red overlay
 
@@ -132,6 +157,8 @@ class MaskOverlayViewer(QWidget):
         self.image_label.setPixmap(pixmap)
 
     def toggle_play(self):
+        if not self.dicom_slices or not self.mask_images:
+            return
         if self.timer.isActive():
             self.timer.stop()
             self.play_button.setText("Play")
@@ -140,6 +167,8 @@ class MaskOverlayViewer(QWidget):
             self.play_button.setText("Pause")
 
     def next_slice(self):
+        if not self.dicom_slices or not self.mask_images:
+            return
         idx = self.current_index + 1
         if idx >= len(self.dicom_slices):
             self.timer.stop()

--- a/internal/frontend_service/viewers/single_slice_viewer.py
+++ b/internal/frontend_service/viewers/single_slice_viewer.py
@@ -1,28 +1,104 @@
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout, QFileDialog, QMessageBox
-from PyQt5.QtGui import QPixmap
-from utils.image_utils import get_qimage
+from typing import List, Optional
+
 import pydicom
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from utils.image_utils import get_qimage
+
 
 class SingleSliceViewer(QWidget):
-    def __init__(self):
+    def __init__(
+        self,
+        accession: Optional[dict] = None,
+        dicom_slices: Optional[List[pydicom.dataset.Dataset]] = None,
+    ):
         super().__init__()
         self.setWindowTitle("Single Slice Viewer")
+
+        self.accession = accession or {}
+        self.dicom_slices: List[pydicom.dataset.Dataset] = dicom_slices or []
+        self.current_index = 0
+
         layout = QVBoxLayout()
+
         self.label = QLabel("No image loaded")
         self.label.setAlignment(Qt.AlignCenter)
         layout.addWidget(self.label)
-        self.setLayout(layout)
-        self.show_slice()
 
-    def show_slice(self):
-        file, _ = QFileDialog.getOpenFileName(self, "Select DICOM File", "", "All Files (*)")
-        if not file:
+        controls = QHBoxLayout()
+        self.prev_button = QPushButton("Previous")
+        self.prev_button.clicked.connect(lambda: self._change_slice(-1))
+        controls.addWidget(self.prev_button)
+
+        self.next_button = QPushButton("Next")
+        self.next_button.clicked.connect(lambda: self._change_slice(1))
+        controls.addWidget(self.next_button)
+
+        self.load_button = QPushButton("Load Local File")
+        self.load_button.clicked.connect(self.load_local_slice)
+        controls.addWidget(self.load_button)
+
+        layout.addLayout(controls)
+
+        self.setLayout(layout)
+
+        if self.dicom_slices:
+            self._display_slice(0)
+        else:
+            self._update_controls()
+
+    # ------------------------------------------------------------------
+    def _change_slice(self, delta: int) -> None:
+        if not self.dicom_slices:
+            return
+        new_index = self.current_index + delta
+        if 0 <= new_index < len(self.dicom_slices):
+            self._display_slice(new_index)
+
+    def _display_slice(self, index: int) -> None:
+        self.current_index = index
+        dataset = self.dicom_slices[index]
+        qimg = get_qimage(dataset)
+        pixmap = QPixmap.fromImage(qimg).scaled(
+            700,
+            700,
+            Qt.KeepAspectRatio,
+            Qt.SmoothTransformation,
+        )
+        self.label.setPixmap(pixmap)
+        description = dataset.SeriesDescription if hasattr(dataset, "SeriesDescription") else ""
+        title_suffix = f" - {description}" if description else ""
+        if self.accession:
+            dicom_name = self.accession.get("dicom_name")
+            if dicom_name:
+                title_suffix = f" - {dicom_name}{title_suffix}"
+        self.setWindowTitle(f"Single Slice Viewer (Slice {index + 1}/{len(self.dicom_slices)}){title_suffix}")
+        self._update_controls()
+
+    def _update_controls(self) -> None:
+        has_slices = bool(self.dicom_slices)
+        self.prev_button.setEnabled(has_slices and self.current_index > 0)
+        self.next_button.setEnabled(has_slices and self.current_index < len(self.dicom_slices) - 1)
+
+    # ------------------------------------------------------------------
+    def load_local_slice(self) -> None:
+        file_path, _ = QFileDialog.getOpenFileName(self, "Select DICOM File", "", "DICOM Files (*.dcm);;All Files (*)")
+        if not file_path:
             return
         try:
-            dcm = pydicom.dcmread(file, force=True)
-            img = get_qimage(dcm)
-            pixmap = QPixmap.fromImage(img).scaled(700, 700, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-            self.label.setPixmap(pixmap)
-        except Exception as e:
-            QMessageBox.critical(self, "Error", f"Failed to load file:\n{str(e)}")
+            dataset = pydicom.dcmread(file_path, force=True)
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"Failed to load file:\n{exc}")
+            return
+        self.dicom_slices = [dataset]
+        self._display_slice(0)


### PR DESCRIPTION
## Summary
- add an authenticated API client and login window so the frontend can obtain JWT tokens
- update the main menu to manage session lists, uploads, downloads, and viewer launches via the protected endpoints
- adapt the viewer widgets to consume remotely fetched DICOM and mask data while keeping local fallbacks

## Testing
- python -m compileall internal/frontend_service

------
https://chatgpt.com/codex/tasks/task_e_68f5bb39457c832c89a63ce573863ec4